### PR TITLE
topic/issue_19: ユースケース「アカウント作成の申請をする」追加要件: ビジネスロジック処理へのプロフィール項目を追加した

### DIFF
--- a/BizLogics/Uam/Aggregate/User/Exception/BirthDateStrInvalidException.php
+++ b/BizLogics/Uam/Aggregate/User/Exception/BirthDateStrInvalidException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Bizlogics\Uam\Aggregate\User\Exception;
+
+use RuntimeException;
+
+final class BirthDateStrInvalidException extends RuntimeException
+{
+
+}

--- a/BizLogics/Uam/Aggregate/User/Exception/FullNameSizeTooLongException.php
+++ b/BizLogics/Uam/Aggregate/User/Exception/FullNameSizeTooLongException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Bizlogics\Uam\Aggregate\User\Exception;
+
+use RuntimeException;
+
+final class FullNameSizeTooLongException extends RuntimeException
+{
+
+}

--- a/BizLogics/Uam/UseCase/UserOperation/CreateAccount/CreateAccountUseCase.php
+++ b/BizLogics/Uam/UseCase/UserOperation/CreateAccount/CreateAccountUseCase.php
@@ -27,7 +27,7 @@ final class CreateAccountUseCase
         $this->userRepos = $userRepos;
     }
 
-    public function execute(string $email, string $password): Result
+    public function execute(string $email, string $password, ?string $fullName = null, ?string $birthDateStr = null): Result
     {
         $result = new Result();
         try {
@@ -37,7 +37,7 @@ final class CreateAccountUseCase
                     ? new ApplyingException()
                     : new EmailAlreadyUsedException();
             }
-            $user = User::buildForCreate($email, $password);
+            $user = User::buildForCreate($email, $password, $fullName, $birthDateStr);
             $this->userRepos->save($user);
         } catch (ApplyingException $e) {
             $result->setFailure($e, self::E_MSG_EMAIL_APPLYING);

--- a/BizLogics/Uam/UseCase/UserOperation/CreateAccount/CreateAccountUseCase.php
+++ b/BizLogics/Uam/UseCase/UserOperation/CreateAccount/CreateAccountUseCase.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Bizlogics\Uam\UseCase\UserOperation\CreateAccount;
 
+use Bizlogics\Uam\Aggregate\User\Exception\BirthDateStrInvalidException;
+use Bizlogics\Uam\Aggregate\User\Exception\FullNameSizeTooLongException;
 use Bizlogics\Uam\Aggregate\User\Exception\PasswordSizeTooShortException;
 use Bizlogics\Uam\Aggregate\User\Exception\PasswordTypeCompositionInvalidException;
 use Bizlogics\Uam\Aggregate\User\User;
@@ -18,6 +20,8 @@ final class CreateAccountUseCase
     public const E_MSG_PASSWORD_BASE = "パスワードが要件を満たしていません。";
     public const E_MSG_PASSWORD_SIZE_TOO_SHORT = "[" . User::PASSWORD_MIN_LENGTH . "文字以上必要]";
     public const E_MSG_PASSWORD_TYPE_INVALID = "[半角大小英数字で構成する]";
+    public const E_MSG_FULL_NAME_SIZE_TOO_LONG = "氏名の文字列が長すぎます。";
+    public const E_MSG_BIRTH_DATE_STR_INVALID = "生年月日の文字列が不正です。";
 
     /**
      * CreateAccountUseCase constructor.
@@ -47,6 +51,10 @@ final class CreateAccountUseCase
             $result->setFailure($e, self::E_MSG_PASSWORD_BASE . self::E_MSG_PASSWORD_SIZE_TOO_SHORT);
         } catch (PasswordTypeCompositionInvalidException $e) {
             $result->setFailure($e, self::E_MSG_PASSWORD_BASE . self::E_MSG_PASSWORD_TYPE_INVALID);
+        } catch (FullNameSizeTooLongException $e) {
+            $result->setFailure($e, self::E_MSG_FULL_NAME_SIZE_TOO_LONG);
+        } catch (BirthDateStrInvalidException $e) {
+            $result->setFailure($e, self::E_MSG_BIRTH_DATE_STR_INVALID);
         }
 
         return $result;

--- a/app/Http/Controllers/Uam/UserOperation/CreateAccountController.php
+++ b/app/Http/Controllers/Uam/UserOperation/CreateAccountController.php
@@ -36,8 +36,10 @@ final class CreateAccountController extends BaseController
     {
         $email = $request->get('email');
         $password = $request->get('password');
+        $fullName = $request->get('full-name');
+        $birthDate = $request->get('birth-date');
         try {
-            $result = $this->useCase->execute($email, ($password ?? ''));
+            $result = $this->useCase->execute($email, ($password ?? ''), $fullName, $birthDate);
         } catch (RegistrationProcessFailedException $e) {
             logger(__METHOD__, [get_class($e), $e->getMessage()]);
             return redirect('/e');

--- a/app/Infrastructure/Uam/AggregateRepository/User/ForTestUserAggregateRepository.php
+++ b/app/Infrastructure/Uam/AggregateRepository/User/ForTestUserAggregateRepository.php
@@ -39,13 +39,17 @@ final class ForTestUserAggregateRepository implements UserAggregateRepositoryInt
             self::例外用_ユーザID_1_申請中,
             self::例外用_ユーザID_1_申請中メールアドレス,
             self::テスト用Password,
-            AccountStatus::applying()->raw()
+            AccountStatus::applying()->raw(),
+            null,
+            null
         ));
         $this->save(User::buildForTestData(
             self::例外用_ユーザID_2_既に使用中,
             self::例外用_ユーザID_2_既に使用されているメールアドレス,
             self::テスト用Password,
-            AccountStatus::inOperation()->raw()
+            AccountStatus::inOperation()->raw(),
+            null,
+            null
         ));
     }
 
@@ -78,7 +82,9 @@ final class ForTestUserAggregateRepository implements UserAggregateRepositoryInt
                 $id,
                 $userAggregate->email(),
                 $userAggregate->password(),
-                $userAggregate->accountStatus()
+                $userAggregate->accountStatus(),
+                $userAggregate->fullName(),
+                $userAggregate->birthDateStr()
             );
         }
         $this->userDao[$id] = $userAggregate;

--- a/app/Infrastructure/Uam/TableModel/UserAccountBase.php
+++ b/app/Infrastructure/Uam/TableModel/UserAccountBase.php
@@ -12,6 +12,7 @@ use Bizlogics\Uam\UseCase\UserOperation\Login\AuthenticatableInterface as BizLog
  * @property $account_status
  * @property $email
  * @property $password
+ * @property $user_account_profile_id
  */
 class UserAccountBase extends Authenticatable implements BizLogicsAuth
 {
@@ -26,6 +27,7 @@ class UserAccountBase extends Authenticatable implements BizLogicsAuth
         'account_status',
         'email',
         'password',
+        'user_account_profile_id',
     ];
 
     /**
@@ -40,5 +42,10 @@ class UserAccountBase extends Authenticatable implements BizLogicsAuth
     public function getId(): int
     {
         return $this->id;
+    }
+
+    public function userAccountProfile()
+    {
+        return $this->belongsTo(UserAccountProfile::class, 'user_account_profile_id', 'id');
     }
 }

--- a/app/Infrastructure/Uam/TableModel/UserAccountProfile.php
+++ b/app/Infrastructure/Uam/TableModel/UserAccountProfile.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Infrastructure\Uam\TableModel;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @method static self find($id)
+ * @method static \Illuminate\Database\Eloquent\Builder where($string, $string)
+ * @property $id
+ * @property $birth_date_str
+ * @property $full_name
+ */
+class UserAccountProfile extends Model
+{
+    protected $table = 'user_account_profile';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'birth_date_str',
+        'full_name',
+    ];
+
+    public function userAccountBase()
+    {
+        return $this->hasOne(UserAccountBase::class, 'user_account_profile_id');
+    }
+}

--- a/database/migrations/2021_07_13_180935_create_user_account_profile_table.php
+++ b/database/migrations/2021_07_13_180935_create_user_account_profile_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserAccountProfileTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_account_profile', function (Blueprint $table) {
+            $table->id();
+            $table->string('birth_date_str');
+            $table->string('full_name');
+            $table->timestamps();
+        });
+
+        Schema::table('user_account_base', function (Blueprint $table) {
+            $table->bigInteger('user_account_profile_id')->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_account_profile');
+        Schema::table('user_account_base', function (Blueprint $table) {
+            $table->dropColumn('user_account_profile_id');
+        });
+    }
+}

--- a/database/seeders/UserAccountSeeder.php
+++ b/database/seeders/UserAccountSeeder.php
@@ -15,10 +15,17 @@ class UserAccountSeeder extends Seeder
      */
     public function run()
     {
+        $profId = DB::table('user_account_profile')->insertGetId([
+            'birth_date_str' => "",
+            'full_name' => "",
+        ]);
         DB::table('user_account_base')->insert([
             'account_status' => 0,
             'email' => 'hoge01@example.local',
             'password' => Hash::make('hoge01TEST'),
+            'user_account_profile_id' => $profId,
         ]);
+
+
     }
 }

--- a/tests/Feature/Http/Controllers/Uam/UserOperation/CreateAccountControllerTest.php
+++ b/tests/Feature/Http/Controllers/Uam/UserOperation/CreateAccountControllerTest.php
@@ -3,10 +3,20 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Http\Controllers\Uam\UserOperation;
 
+use App\Infrastructure\Uam\AggregateRepository\User\ForTestUserAggregateRepository;
+use Bizlogics\Uam\Aggregate\UserAggregateRepositoryInterface;
 use Tests\LaraTestCase;
 
 final class CreateAccountControllerTest extends LaraTestCase
 {
+    private UserAggregateRepositoryInterface|ForTestUserAggregateRepository $userRepo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userRepo = ForTestUserAggregateRepository::getInstance();
+    }
+
     /**
      * @noinspection NonAsciiCharacters
      * @test
@@ -15,6 +25,42 @@ final class CreateAccountControllerTest extends LaraTestCase
     {
         $response = $this->get('/uam/create-account/new');
         $response->assertStatus(200);
+    }
+
+    /**
+     * @noinspection NonAsciiCharacters
+     * @test
+     */
+    public function アカウント作成の申請をする_一般ユーザを「申請中」として記録する(): void
+    {
+        $data = [
+            'email' => $this->userRepo->使われていないメールアドレスを生成する(),
+            'password' => ForTestUserAggregateRepository::テスト用Password,
+            'full-name' => 'ほげTEST',
+            'birth-date' => '19800101'
+        ];
+
+        $this->instance(
+            /*
+             * DIするインスタンスを「DAOを持たないテスト用Repository実装」に差し替える。
+             * （Featureテストのような use CreatesApplication しているテストクラスの場合はこれをしてあげないとDBが飛ぶ恐れあり）
+             */
+            UserAggregateRepositoryInterface::class,
+            ForTestUserAggregateRepository::getInstance()
+        );
+
+        $response = $this->post('/uam/create-account', $data);
+        $response->assertRedirect('/');
+
+        $data = [
+            'email' => $this->userRepo->使われていないメールアドレスを生成する(),
+            'password' => ForTestUserAggregateRepository::テスト用Password,
+            'full-name' => 'ほげTEST',
+            'birth-date' => '19800140'
+        ];
+        $response = $this->post('/uam/create-account', $data);
+        $response->assertSessionHasErrors();
+
     }
 
 


### PR DESCRIPTION
# 関連する課題

issue #19

# 実装内容

- 対応するUseCaseクラスのUnitテストへのテスト項目追加
- 対応するControllerクラスのFeatureテストへのテスト項目追加
- migrationファイルの追加とseeder刷新およびそれらに対応するEloquentモデルクラスの追加
    - user_account_baseテーブルと user_account_profileテーブルにリレーションを設定
- UseCaseクラス以降へ追加要件処理の実装


# 未実装の内容

- アカウント作成時の「氏名」および「生年月日」のview側入力欄